### PR TITLE
feat:회원가입 페이지 구현(#6)

### DIFF
--- a/src/components/atoms/RequiredInput/RequiredInput.js
+++ b/src/components/atoms/RequiredInput/RequiredInput.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 const RequiredInput = ({ type, placeholder }) => {
-  return <input type={type} placeholder={placeholder} />;
+  return <input required type={type} placeholder={placeholder} />;
 };
 
 export default RequiredInput;

--- a/src/components/molecules/InputButtonPair/InputButtonPair.js
+++ b/src/components/molecules/InputButtonPair/InputButtonPair.js
@@ -7,11 +7,11 @@ const InputButtonPair = ({
   placeholder,
   text,
 }) => {
-  return
-  (<div>
-    <RequiredInput type={type} placeholder={placeholder} />
-    <SubmitButton text={text}> </SubmitButton>
-  </div>);
+  return(
+    <div>
+      <RequiredInput type={type} placeholder={placeholder} />
+      <SubmitButton text={text} />
+    </div>);
 };
 
 export default InputButtonPair;

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -25,6 +25,7 @@ const Login = () => {
         placeholder2="Password"
       />
       <SubmitButton text="로그인" />
+      <InternalLink text="회원가입" href="/signup"/>
       <InternalLink text="아이디" />
       /
       <InternalLink text="비밀번호를 잊으셨나요?" />

--- a/src/pages/SignUp/SignUp.js
+++ b/src/pages/SignUp/SignUp.js
@@ -1,8 +1,61 @@
-import React from 'react';
-import "pages/SignUp/SignUp.css";
+// import React from 'react';
+// import "pages/SignUp/SignUp.css";
+
+// const SignUp = () => {
+//     return <div>SignUp Page</div>;
+// }
+
+// export default SignUp;
+import React from "react";
+import "./SignUp.css";
+import InputPair from "components/molecules/InputPair/InputPair";
+import SubmitButton from "components/atoms/SubmitButton/SubmitButton";
+import InternalLink from "components/atoms/InternalLink/InternalLink";
+import LoginInput from "components/atoms/LoginInput/LoginInput";
+import TitleBlock from "components/molecules/TitleBlock/TitleBlock";
+import InputButtonPair from "components/molecules/InputButtonPair/InputButtonPair";
 
 const SignUp = () => {
-    return <div>SignUp Page</div>;
-}
+  return (
+    <div>
+      <TitleBlock text1="지스트 청원 사이트" text2="계정 만들기" />
+      <InputPair
+        type1="text"
+        placeholder1="이름"
+        type2="text"
+        placeholder2="입학년도"
+      />
+      <div>
+        <select name="" id="track">
+          <option value="">대학생</option>
+          <option value="">대학원생</option>
+        </select>
+        <select name="" id="major">
+          <option value="">기초교육학부</option>
+          <option value="">기계공학</option>
+          <option value="">물리학</option>
+          <option value="">생명과학</option>
+          <option value="">신소재공학</option>
+          <option value="">전전컴</option>
+          <option value="">화학</option>
+          <option value="">환경공학</option>
+        </select>
+      </div>
+      <InputButtonPair type="text" placeholder="ID" text="중복확인" />
+      <LoginInput type="text" text="Email" />
+      <InputPair
+        type1="password"
+        placeholder1="Password"
+        type2="password"
+        placeholder2="Password check"
+      />
+      <LoginInput type="checkbox" text="" />
+      지스트 청원 사이트
+      <InternalLink text="가입약관" />에 동의합니다.
+      <LoginInput type="text" />
+      <SubmitButton text="가입하기" />
+    </div>
+  );
+};
 
 export default SignUp;


### PR DESCRIPTION
## 개요

- 회원가입 페이지 구현

## 작업사항

- 와이어프레임 그대로 구현
- 컴포넌트를 이용한 구현
![image](https://user-images.githubusercontent.com/68385607/126054521-a54d0a8b-ffb8-4e50-83cc-06b9f18e15ff.png)

## 참고

- 하드코딩에서는 이메일 인증 버튼을 누르면 이메일 코드 입력란과 가입하기 버튼이 나왔었는데,  jsx로 넘어오며 미구현 상태
- login -> 회원가입 anchor를 통해 페이지 확인 가능

## 연결된 이슈

- closes #6 
